### PR TITLE
Merge: feature/profile to staging

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -718,14 +718,13 @@ export default function DashboardPage() {
                       onClick={handleCopyShare}
                       className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:border-accent-primary/50 text-xs font-heading uppercase tracking-wider transition-colors"
                     >
-                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden>
-                        <circle cx="18" cy="5" r="3" />
-                        <circle cx="6" cy="12" r="3" />
-                        <circle cx="18" cy="19" r="3" />
-                        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-                        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
                       </svg>
-                      {copiedShare ? "Copied" : "Share"}
+                      <span key={copiedShare ? "copied" : "share"} style={copiedShare ? { animation: "pop 250ms cubic-bezier(0.16, 1, 0.3, 1) both", display: "inline-block" } : undefined}>
+                        {copiedShare ? "Copied" : "Share"}
+                      </span>
                     </button>
                   </div>
                 </div>
@@ -800,8 +799,9 @@ export default function DashboardPage() {
                 </p>
                 <div className="w-full rounded-full overflow-hidden" style={{ backgroundColor: "rgba(255,255,255,0.07)", height: "3px" }}>
                   <div
-                    className="h-full rounded-full bg-accent-highlight"
+                    className="h-full rounded-full"
                     style={{
+                      backgroundColor: teamColor,
                       width: "100%",
                       transformOrigin: "left center",
                       transform: `scaleX(${barsReady ? xpProgress.pctToNextLevel / 100 : 0})`,
@@ -812,7 +812,7 @@ export default function DashboardPage() {
               </div>
               <div className="rounded-2xl border border-border bg-surface p-4">
                 <p className="text-[10px] font-sans uppercase tracking-widest text-text-muted mb-2">Quests Done</p>
-                <p className="font-heading text-4xl tabular-nums text-accent-highlight leading-none mb-1">{completedQuestCount}</p>
+                <p className="font-heading text-4xl tabular-nums leading-none mb-1" style={{ color: teamColor }}>{completedQuestCount}</p>
                 <p className="text-[11px] text-text-muted font-sans">milestones earned</p>
               </div>
               <div className="rounded-2xl border border-border bg-surface p-4">
@@ -839,9 +839,12 @@ export default function DashboardPage() {
                 </div>
                 <Link
                   href={`/events/${pendingReflection.eventId}/reflect`}
-                  className="shrink-0 inline-flex items-center justify-center px-4 py-2 rounded-xl bg-[#F97316] hover:bg-[#ea580c] text-white text-xs font-heading transition-colors"
+                  className="shrink-0 inline-flex items-center justify-center gap-1.5 px-4 py-2 rounded-xl bg-[#F97316] hover:bg-[#ea580c] text-white text-xs font-heading transition-colors"
                 >
-                  Submit Now →
+                  Submit Now
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                    <polyline points="9 18 15 12 9 6" />
+                  </svg>
                 </Link>
               </div>
             ) : null}
@@ -852,7 +855,7 @@ export default function DashboardPage() {
                 className="mb-4"
                 style={{ animation: "fade-up 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms both" }}
               >
-                <h2 className="font-heading text-[11px] text-text-secondary mb-3 uppercase tracking-widest">Coordinator</h2>
+                <h2 className="font-heading text-sm text-text-primary mb-3">Coordinator</h2>
                 <div className="grid grid-cols-2 gap-3 mb-3">
                   <Link
                     href="/quests?tab=approvals"
@@ -908,8 +911,20 @@ export default function DashboardPage() {
                 </Link>
               </div>
               {activeQuestCards.length === 0 ? (
-                <div className="rounded-2xl border border-border bg-surface px-5 py-8 text-center">
-                  <p className="text-sm text-text-muted font-sans">No active quests right now. Head to Quests to see what&#39;s available.</p>
+                <div className="rounded-2xl border border-border bg-surface px-5 py-8 flex flex-col items-center gap-3 text-center">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="text-text-muted" aria-hidden style={{ animation: "float 3s ease-in-out infinite" }}>
+                    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                  </svg>
+                  <div>
+                    <p className="font-heading text-sm text-text-primary mb-1">No active quests yet</p>
+                    <p className="text-xs text-text-muted font-sans max-w-[22ch] mx-auto">Complete your team&#39;s associate-tier quests to advance your career path.</p>
+                  </div>
+                  <Link
+                    href="/quests"
+                    className="inline-flex items-center justify-center border border-border rounded-xl px-4 py-2 text-xs font-heading text-text-secondary hover:text-text-primary hover:border-accent-primary/50 transition-colors"
+                  >
+                    Browse Quests
+                  </Link>
                 </div>
               ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -917,7 +932,7 @@ export default function DashboardPage() {
                     <Link
                       key={q.questId}
                       href="/quests"
-                      className="rounded-2xl border border-border bg-surface p-4 hover:border-accent-primary/50 transition-colors flex flex-col gap-2.5"
+                      className="rounded-2xl border border-border bg-surface p-4 hover:border-accent-primary/50 hover:scale-[1.01] transition-[transform,border-color] flex flex-col gap-2.5"
                       style={{
                         animation: `fade-up 400ms cubic-bezier(0.16, 1, 0.3, 1) ${135 + i * 60}ms both`,
                       }}
@@ -956,8 +971,23 @@ export default function DashboardPage() {
                 </Link>
               </div>
               {upcomingChapterEvents.length === 0 ? (
-                <div className="rounded-2xl border border-border bg-surface px-5 py-8 text-center">
-                  <p className="text-sm text-text-muted font-sans">No upcoming events in your chapter. Check back soon.</p>
+                <div className="rounded-2xl border border-border bg-surface px-5 py-8 flex flex-col items-center gap-3 text-center">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="text-text-muted" aria-hidden style={{ animation: "float 3s ease-in-out 300ms infinite" }}>
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                    <line x1="16" y1="2" x2="16" y2="6" />
+                    <line x1="8" y1="2" x2="8" y2="6" />
+                    <line x1="3" y1="10" x2="21" y2="10" />
+                  </svg>
+                  <div>
+                    <p className="font-heading text-sm text-text-primary mb-1">No upcoming events</p>
+                    <p className="text-xs text-text-muted font-sans max-w-[26ch] mx-auto">Your chapter coordinator will post events here when they&#39;re scheduled.</p>
+                  </div>
+                  <Link
+                    href="/events"
+                    className="inline-flex items-center justify-center border border-border rounded-xl px-4 py-2 text-xs font-heading text-text-secondary hover:text-text-primary hover:border-accent-primary/50 transition-colors"
+                  >
+                    View All Events
+                  </Link>
                 </div>
               ) : (
                 <div className="flex gap-3 overflow-x-auto pb-2 snap-x snap-mandatory scrollbar-minimal -mx-4 px-4 sm:-mx-6 sm:px-6">
@@ -1003,10 +1033,10 @@ export default function DashboardPage() {
 
       {showAvatarEditor && userData ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
-          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => !savingAvatar && setShowAvatarEditor(false)} role="presentation" />
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => !savingAvatar && setShowAvatarEditor(false)} role="presentation" style={{ animation: "fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both" }} />
           <div
             className="relative border border-border rounded-2xl w-full max-w-sm max-h-[90vh] flex flex-col shadow-2xl"
-            style={{ backgroundColor: "#1a1625" }}
+            style={{ backgroundColor: "#1a1625", animation: "modal-in 350ms cubic-bezier(0.16, 1, 0.3, 1) both" }}
           >
             <div className="flex items-center justify-between px-5 py-4 border-b border-border flex-shrink-0">
               <h2 className="font-heading text-[1rem] text-white">Customize Avatar</h2>

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -324,7 +324,7 @@ function HeaderCard({
 
       <div className="border border-border rounded-2xl overflow-hidden" style={{ backgroundColor: "#100c1a" }}>
         <div className="px-5 py-3 border-b border-border flex items-center justify-between">
-          <span className="text-[11px] font-sans uppercase tracking-widest text-text-muted">Account</span>
+          <span className="font-heading text-sm text-text-primary">Account</span>
           <span
             className="text-[10px] font-sans uppercase tracking-widest px-2.5 py-1 rounded-full border"
             style={
@@ -462,6 +462,7 @@ function TierLadderRow({
   completedAt,
   completedCount,
   totalQuests,
+  barsReady,
 }: {
   tier: Quest["tier"];
   status: TierLadderStatus;
@@ -470,6 +471,7 @@ function TierLadderRow({
   completedAt: Timestamp | null;
   completedCount: number;
   totalQuests: number;
+  barsReady?: boolean;
 }) {
   const label = tier === "lead" ? leadTitle : (TIER_LABELS[tier] ?? tier);
 
@@ -528,10 +530,13 @@ function TierLadderRow({
             </p>
             <div className="h-2 rounded-full bg-border mt-2 overflow-hidden">
               <div
-                className="h-full rounded-full transition-all duration-500"
+                className="h-full rounded-full"
                 style={{
-                  width: `${totalQuests ? (completedCount / totalQuests) * 100 : 0}%`,
+                  width: "100%",
                   backgroundColor: teamColor,
+                  transformOrigin: "left center",
+                  transform: `scaleX(${barsReady ? (totalQuests ? completedCount / totalQuests : 0) : 0})`,
+                  transition: barsReady ? "transform 700ms cubic-bezier(0.16, 1, 0.3, 1) 150ms" : "none",
                 }}
               />
             </div>
@@ -562,6 +567,13 @@ function MilestonesSection({
   const meta = TEAM_META[activeTeam];
   const color = meta?.color ?? "#A855F7";
   const leadTitle = meta?.leadTitle ?? TIER_LABELS.lead;
+
+  const [barsReady, setBarsReady] = useState(false);
+  useEffect(() => {
+    setBarsReady(false);
+    const t = setTimeout(() => setBarsReady(true), 300);
+    return () => clearTimeout(t);
+  }, [activeTeam]);
 
   return (
     <div className="rounded-2xl bg-surface border border-border p-6 flex flex-col gap-4">
@@ -608,6 +620,7 @@ function MilestonesSection({
               completedAt={date}
               completedCount={completedCount}
               totalQuests={totalQuests}
+              barsReady={barsReady}
             />
           );
         })}
@@ -656,7 +669,7 @@ function ActivityFeed({
             const bg = xpLogSourceIconColor(e.source);
             const ts = e.createdAt;
             return (
-              <li key={`${e.logId ?? ts?.toMillis?.() ?? i}-${i}`} className="flex gap-3 items-start">
+              <li key={`${e.logId ?? ts?.toMillis?.() ?? i}-${i}`} className="flex gap-3 items-start" style={{ animation: `fade-up 400ms cubic-bezier(0.16, 1, 0.3, 1) ${Math.min(i, 7) * 45}ms both` }}>
                 <div
                   className="w-9 h-9 rounded-full shrink-0 flex items-center justify-center"
                   style={{ backgroundColor: `${bg}33` }}
@@ -735,15 +748,15 @@ function PortfolioCard({
       </div>
       <div className="grid grid-cols-3 gap-2 text-center">
         <div className="rounded-lg bg-[#0a0a0f] border border-border py-2 px-1">
-          <p className="text-lg font-heading text-[#06B6D4] tabular-nums">{eventCount}</p>
+          <p className="text-lg font-heading text-[#06B6D4] tabular-nums" style={{ animation: "count-pulse 600ms cubic-bezier(0.16, 1, 0.3, 1) 350ms 1 both" }}>{eventCount}</p>
           <p className="text-[10px] text-text-muted font-sans leading-tight">Events contributed</p>
         </div>
         <div className="rounded-lg bg-[#0a0a0f] border border-border py-2 px-1">
-          <p className="text-lg font-heading text-[#FACC15] tabular-nums">{reflectionCount}</p>
+          <p className="text-lg font-heading text-[#FACC15] tabular-nums" style={{ animation: "count-pulse 600ms cubic-bezier(0.16, 1, 0.3, 1) 450ms 1 both" }}>{reflectionCount}</p>
           <p className="text-[10px] text-text-muted font-sans leading-tight">Reflections</p>
         </div>
         <div className="rounded-lg bg-[#0a0a0f] border border-border py-2 px-1">
-          <p className="text-lg font-heading text-[#A855F7] tabular-nums">{badgesEarned}</p>
+          <p className="text-lg font-heading text-[#A855F7] tabular-nums" style={{ animation: "count-pulse 600ms cubic-bezier(0.16, 1, 0.3, 1) 550ms 1 both" }}>{badgesEarned}</p>
           <p className="text-[10px] text-text-muted font-sans leading-tight">Badges earned</p>
         </div>
       </div>
@@ -752,7 +765,9 @@ function PortfolioCard({
         onClick={onCopyShare}
         className="w-full py-3 rounded-xl font-heading font-semibold bg-accent-highlight text-white hover:bg-accent-primary transition-colors"
       >
-        {copied ? "Copied!" : "Copy Share Link"}
+        <span key={copied ? "copied" : "share"} style={copied ? { animation: "pop 250ms cubic-bezier(0.16, 1, 0.3, 1) both", display: "inline-block" } : undefined}>
+          {copied ? "Copied!" : "Copy Share Link"}
+        </span>
       </button>
     </div>
   );
@@ -770,7 +785,7 @@ interface BadgeDef {
 function BadgeTile({ badge }: { badge: BadgeDef }) {
   return (
     <div
-      className="relative rounded-xl border border-border bg-[#0a0a0f] p-4 flex flex-col items-center gap-2 text-center group"
+      className="relative rounded-xl border border-border bg-[#0a0a0f] p-4 flex flex-col items-center gap-2 text-center group hover:scale-[1.03] transition-transform duration-200"
       title={badge.earned ? "Earned" : badge.description}
     >
       <div
@@ -1162,32 +1177,42 @@ export default function ProfilePage() {
       <div className="flex-1 overflow-y-auto p-6">
         <div className="max-w-3xl lg:max-w-5xl mx-auto flex flex-col gap-5">
           <>
-              <HeaderCard
-                userData={userData}
-                avatarUrl={avatarUrl}
-                onGenerateResume={handleGenerateResume}
-                isGeneratingResume={isGeneratingResume}
-              />
-              {milestoneTeam ? (
-                <MilestonesSection
+              <div style={{ animation: "fade-up 500ms cubic-bezier(0.16, 1, 0.3, 1) both" }}>
+                <HeaderCard
                   userData={userData}
+                  avatarUrl={avatarUrl}
+                  onGenerateResume={handleGenerateResume}
+                  isGeneratingResume={isGeneratingResume}
+                />
+              </div>
+              {milestoneTeam ? (
+                <div style={{ animation: "fade-up 500ms cubic-bezier(0.16, 1, 0.3, 1) 60ms both" }}>
+                  <MilestonesSection
+                    userData={userData}
+                    completions={completions}
+                    allQuests={allQuests}
+                    activeTeam={milestoneTeam}
+                    onTeamChange={setActiveTeam}
+                  />
+                </div>
+              ) : null}
+              <div style={{ animation: "fade-up 500ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both" }}>
+                <PortfolioCard
                   completions={completions}
                   allQuests={allQuests}
-                  activeTeam={milestoneTeam}
-                  onTeamChange={setActiveTeam}
+                  eventCount={eventCount}
+                  reflectionCount={reflectionCount}
+                  badgesEarned={badgesEarned}
+                  onCopyShare={handleCopyShare}
+                  copied={copied}
                 />
-              ) : null}
-              <PortfolioCard
-                completions={completions}
-                allQuests={allQuests}
-                eventCount={eventCount}
-                reflectionCount={reflectionCount}
-                badgesEarned={badgesEarned}
-                onCopyShare={handleCopyShare}
-                copied={copied}
-              />
-              <BadgesGrid badges={badges} />
-              <ActivityFeed entries={activityEntries} hasMore={activityHasMore} />
+              </div>
+              <div style={{ animation: "fade-up 500ms cubic-bezier(0.16, 1, 0.3, 1) 180ms both" }}>
+                <BadgesGrid badges={badges} />
+              </div>
+              <div style={{ animation: "fade-up 500ms cubic-bezier(0.16, 1, 0.3, 1) 240ms both" }}>
+                <ActivityFeed entries={activityEntries} hasMore={activityHasMore} />
+              </div>
             </>
         </div>
       </div>

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -349,7 +349,7 @@ export default function SettingsPage() {
           {/* ── Profile info ── */}
           <section className="rounded-2xl border border-border bg-surface overflow-hidden">
             <div className="px-5 py-3 border-b border-border">
-              <span className="text-[11px] font-sans uppercase tracking-widest text-text-muted">Profile Info</span>
+              <span className="font-heading text-sm text-text-primary">Profile Info</span>
             </div>
             <div className="px-5 py-5 flex flex-col gap-4">
               <Field label="Username">
@@ -411,7 +411,7 @@ export default function SettingsPage() {
           {/* ── Volunteer teams ── */}
           <section className="rounded-2xl border border-border bg-surface overflow-hidden">
             <div className="px-5 py-3 border-b border-border">
-              <span className="text-[11px] font-sans uppercase tracking-widest text-text-muted">Volunteer Teams</span>
+              <span className="font-heading text-sm text-text-primary">Volunteer Teams</span>
             </div>
             <div className="px-5 py-5 flex flex-col gap-3">
               <p className="text-xs text-text-muted font-sans">
@@ -448,7 +448,7 @@ export default function SettingsPage() {
                         className="shrink-0 px-3 py-1.5 rounded-lg border border-border text-xs font-sans text-text-muted hover:text-red-400 hover:border-red-500/40 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                         title={isOnly ? "You must remain on at least one team" : undefined}
                       >
-                        {isLoading ? "…" : "Leave"}
+                        {isLoading ? "Leaving…" : "Leave"}
                       </button>
                     ) : (
                       <button
@@ -464,7 +464,7 @@ export default function SettingsPage() {
                           color: meta.color,
                         }}
                       >
-                        {isLoading ? "…" : "Join"}
+                        {isLoading ? "Joining…" : "Join"}
                       </button>
                     )}
                   </div>
@@ -476,7 +476,7 @@ export default function SettingsPage() {
           {/* ── Danger zone ── */}
           <section className="rounded-2xl border border-border bg-surface overflow-hidden">
             <div className="px-5 py-3 border-b border-border">
-              <span className="text-[11px] font-sans uppercase tracking-widest text-text-muted">Account</span>
+              <span className="font-heading text-sm text-text-primary">Account</span>
             </div>
             <div className="px-5 py-5 flex flex-col gap-3">
               <button
@@ -488,46 +488,48 @@ export default function SettingsPage() {
                 {logoutLoading ? "Signing out…" : "Log Out"}
               </button>
 
-              {!confirmDelete ? (
-                <button
-                  type="button"
-                  onClick={() => { setConfirmDelete(true); setDeleteError(""); }}
-                  disabled={logoutLoading || deleteLoading}
-                  className="w-full py-2.5 px-4 rounded-xl font-sans text-sm border border-border text-text-muted hover:text-red-400 hover:border-red-500/40 transition-colors disabled:opacity-50"
-                >
-                  Delete Account
-                </button>
-              ) : (
-                <div className="rounded-xl border border-red-500/25 overflow-hidden" style={{ backgroundColor: "#1a0d0d" }}>
-                  <div className="px-4 pt-4 pb-3">
-                    <p className="text-text-secondary text-xs text-center leading-relaxed mb-1">
-                      This will permanently delete your account and all associated data.
-                    </p>
-                    <p className="text-red-400/80 text-xs text-center mb-4">This cannot be undone.</p>
-                    {deleteError ? (
-                      <p className="text-xs text-red-400 font-sans text-center mb-3">{deleteError}</p>
-                    ) : null}
-                    <div className="flex gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setConfirmDelete(false)}
-                        disabled={deleteLoading}
-                        className="flex-1 border border-border text-text-muted hover:text-text-primary font-sans text-sm py-2.5 rounded-lg transition-colors disabled:opacity-50"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void handleDeleteAccount()}
-                        disabled={deleteLoading}
-                        className="flex-1 border border-red-500/40 text-red-400 hover:bg-red-500/10 font-sans text-sm py-2.5 rounded-lg transition-colors disabled:opacity-50"
-                      >
-                        {deleteLoading ? "Deleting…" : "Yes, Delete"}
-                      </button>
+              <div className="pt-2 border-t border-border">
+                <div className="bg-red-950/30 border border-red-900/40 rounded-xl p-4">
+                  {!confirmDelete ? (
+                    <button
+                      type="button"
+                      onClick={() => { setConfirmDelete(true); setDeleteError(""); }}
+                      disabled={logoutLoading || deleteLoading}
+                      className="w-full py-2.5 px-4 rounded-xl font-sans text-sm border border-red-800/60 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50"
+                    >
+                      Delete Account
+                    </button>
+                  ) : (
+                    <div>
+                      <p className="text-text-secondary text-xs text-center leading-relaxed mb-1">
+                        This will permanently delete your account and all associated data.
+                      </p>
+                      <p className="text-red-400/80 text-xs text-center mb-4">This cannot be undone.</p>
+                      {deleteError ? (
+                        <p className="text-xs text-red-400 font-sans text-center mb-3">{deleteError}</p>
+                      ) : null}
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDelete(false)}
+                          disabled={deleteLoading}
+                          className="flex-1 border border-border text-text-muted hover:text-text-primary font-sans text-sm py-2.5 rounded-lg transition-colors disabled:opacity-50"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleDeleteAccount()}
+                          disabled={deleteLoading}
+                          className="flex-1 border border-red-500/40 text-red-400 hover:bg-red-500/10 font-sans text-sm py-2.5 rounded-lg transition-colors disabled:opacity-50"
+                        >
+                          {deleteLoading ? "Deleting…" : "Yes, Delete"}
+                        </button>
+                      </div>
                     </div>
-                  </div>
+                  )}
                 </div>
-              )}
+              </div>
             </div>
           </section>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,27 @@ body {
   45%       { transform: scale(1.12); }
 }
 
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-4px); }
+}
+
+@keyframes modal-in {
+  from { opacity: 0; transform: scale(0.96) translateY(8px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes pop {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.18); }
+  100% { transform: scale(1); }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   @keyframes fade-up {
     from { opacity: 0; }
@@ -71,5 +92,20 @@ body {
   @keyframes count-pulse {
     0%, 100% { opacity: 1; }
     45%       { opacity: 0.6; }
+  }
+  @keyframes float {
+    0%, 100% { opacity: 0.7; }
+    50%       { opacity: 1; }
+  }
+  @keyframes modal-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  @keyframes pop {
+    0%, 100% { opacity: 1; }
+  }
+  @keyframes fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
   }
 }


### PR DESCRIPTION
- globals.css: add float, modal-in, pop, fade-in keyframes with prefers-reduced-motion overrides
- Dashboard: floating empty-state icons, quest card hover scale, share button pop feedback, avatar modal entrance (fade-in backdrop + modal-in panel)
- Dashboard: typeset section headers, team-colored XP bar + quests stat, improved empty states with CTAs, danger zone separation in settings, loading copy fixes
- Profile: staggered fade-up entrance for all 5 page sections, scaleX tier progress bar with barsReady pattern, badge tile hover scale, activity feed stagger, portfolio stat count-pulse, copy share pop feedback