### PR TITLE
Merge: feature/animate to staging

### DIFF
--- a/app/(dashboard)/events/page.tsx
+++ b/app/(dashboard)/events/page.tsx
@@ -807,7 +807,7 @@ export default function EventsPage() {
             {upcomingFiltered.length > 0 && (
               <>
                 {hasBoth && (
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 animate-fade-up" style={{ animationDelay: "60ms" }}>
                     <span className="font-heading text-xs text-text-secondary uppercase tracking-widest">
                       Upcoming
                     </span>
@@ -834,7 +834,7 @@ export default function EventsPage() {
             {/* Past section */}
             {pastFiltered.length > 0 && (
               <>
-                <div className={`flex items-center gap-3 ${hasBoth ? "mt-4" : ""}`}>
+                <div className={`flex items-center gap-3 animate-fade-up ${hasBoth ? "mt-4" : ""}`} style={{ animationDelay: "60ms" }}>
                   {hasBoth && (
                     <span className="font-heading text-xs text-text-muted uppercase tracking-widest">
                       Past

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -655,7 +655,7 @@ function ActivityFeed({
       </div>
       {entries.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-14 text-text-muted gap-3">
-          <div className="w-14 h-14 rounded-2xl bg-zinc-800/60 flex items-center justify-center">
+          <div className="w-14 h-14 rounded-2xl bg-zinc-800/60 flex items-center justify-center animate-float">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M22 12h-6l-2 3h-4l-2-3H2" />
               <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />

--- a/app/(dashboard)/quests/page.tsx
+++ b/app/(dashboard)/quests/page.tsx
@@ -194,6 +194,13 @@ function HeroProgressCard({
   ).length;
   const pct = total > 0 ? (completedCount / total) * 100 : 0;
 
+  const [barsReady, setBarsReady] = useState(false);
+  useEffect(() => {
+    setBarsReady(false);
+    const t = setTimeout(() => setBarsReady(true), 350);
+    return () => clearTimeout(t);
+  }, [teamId, currentTier]);
+
   return (
     <div
       className="rounded-2xl overflow-hidden border border-[#27272A] relative"
@@ -261,10 +268,16 @@ function HeroProgressCard({
         </div>
 
         {/* Progress bar */}
-        <div className="h-2 w-full rounded-full bg-zinc-800/60">
+        <div className="h-2 w-full rounded-full bg-zinc-800/60 overflow-hidden">
           <div
-            className="h-full rounded-full transition-all duration-500"
-            style={{ width: `${pct}%`, backgroundColor: color }}
+            className="h-full rounded-full"
+            style={{
+              width: "100%",
+              backgroundColor: color,
+              transformOrigin: "left center",
+              transform: `scaleX(${barsReady ? pct / 100 : 0})`,
+              transition: barsReady ? "transform 700ms cubic-bezier(0.16, 1, 0.3, 1) 150ms" : "none",
+            }}
           />
         </div>
       </div>
@@ -424,7 +437,7 @@ function CollapsibleQuestTile({
 
       {/* ── Expanded body ──────────────────────────────────────────────── */}
       {isExpanded && !locked && (
-        <div className="px-4 pb-4 flex flex-col gap-4 border-t border-[#27272A]">
+        <div className="px-4 pb-4 flex flex-col gap-4 border-t border-[#27272A] animate-fade-in">
 
           {/* Status + Method row */}
           <div className="flex items-center gap-2 flex-wrap pt-3">
@@ -1212,7 +1225,7 @@ function QuestsPageContent() {
                 </div>
               ) : approvals.length === 0 ? (
                 <div className="text-center py-16">
-                  <div className="w-14 h-14 rounded-2xl bg-zinc-800/60 flex items-center justify-center mx-auto mb-4">
+                  <div className="w-14 h-14 rounded-2xl bg-zinc-800/60 flex items-center justify-center mx-auto mb-4 animate-float">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#52525B" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                       <polyline points="20 6 9 17 4 12" />
                     </svg>
@@ -1289,25 +1302,26 @@ function QuestsPageContent() {
 
                     {/* Collapsible quest tiles */}
                     <div className="flex flex-col gap-2.5">
-                      {currentTierQuests.map((quest) => {
+                      {currentTierQuests.map((quest, qi) => {
                         const status = getQuestUIStatus(quest, completions, true);
                         return (
-                          <CollapsibleQuestTile
-                            key={quest.questId}
-                            quest={quest}
-                            status={status}
-                            completion={completions[quest.questId]}
-                            teamColor={activeMeta.color}
-                            isExpanded={expandedQuestId === quest.questId}
-                            onToggle={() =>
-                              setExpandedQuestId(
-                                expandedQuestId === quest.questId ? null : quest.questId
-                              )
-                            }
-                            onSelfMark={() => handleSelfMark(quest)}
-                            onSubmitApproval={(n, e) => handleSubmitApproval(quest, n, e)}
-                            submitting={submitting}
-                          />
+                          <div key={quest.questId} className="animate-fade-up" style={{ animationDelay: `${qi * 50}ms` }}>
+                            <CollapsibleQuestTile
+                              quest={quest}
+                              status={status}
+                              completion={completions[quest.questId]}
+                              teamColor={activeMeta.color}
+                              isExpanded={expandedQuestId === quest.questId}
+                              onToggle={() =>
+                                setExpandedQuestId(
+                                  expandedQuestId === quest.questId ? null : quest.questId
+                                )
+                              }
+                              onSelfMark={() => handleSelfMark(quest)}
+                              onSubmitApproval={(n, e) => handleSubmitApproval(quest, n, e)}
+                              submitting={submitting}
+                            />
+                          </div>
                         );
                       })}
                     </div>

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -391,10 +391,10 @@ export default function SettingsPage() {
               </Field>
 
               {saveError ? (
-                <p className="text-xs text-red-400 font-sans">{saveError}</p>
+                <p className="text-xs text-red-400 font-sans animate-fade-in">{saveError}</p>
               ) : null}
               {saveSuccess ? (
-                <p className="text-xs text-green-400 font-sans">Changes saved.</p>
+                <p className="text-xs text-green-400 font-sans animate-fade-in">Changes saved.</p>
               ) : null}
 
               <button
@@ -500,7 +500,7 @@ export default function SettingsPage() {
                       Delete Account
                     </button>
                   ) : (
-                    <div>
+                    <div className="animate-fade-in">
                       <p className="text-text-secondary text-xs text-center leading-relaxed mb-1">
                         This will permanently delete your account and all associated data.
                       </p>
@@ -539,10 +539,10 @@ export default function SettingsPage() {
       {/* ── Avatar editor modal ── */}
       {showAvatarEditor ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
-          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => !savingAvatar && setShowAvatarEditor(false)} role="presentation" />
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => !savingAvatar && setShowAvatarEditor(false)} role="presentation" style={{ animation: "fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both" }} />
           <div
             className="relative border border-border rounded-2xl w-full max-w-sm max-h-[90vh] flex flex-col shadow-2xl"
-            style={{ backgroundColor: "#1a1625" }}
+            style={{ backgroundColor: "#1a1625", animation: "modal-in 350ms cubic-bezier(0.16, 1, 0.3, 1) both" }}
           >
             <div className="flex items-center justify-between px-5 py-4 border-b border-border flex-shrink-0">
               <h2 className="font-heading text-[1rem] text-white">Customize Avatar</h2>


### PR DESCRIPTION
- Quests — HeroProgressCard progress bar now uses the barsReady deferred-fill pattern (matching the dashboard): starts at scaleX(0) and eases to the actual value after a 350ms settle, using 700ms cubic-bezier(0.16, 1, 0.3, 1). Individual quest tiles gain staggered animate-fade-up entrances (50ms between each). Expanded quest body fades in with animate-fade-in. Approvals empty state icon floats with animate-float.
- Events — "Upcoming" and "Past" section headers animate in with animate-fade-up at 60ms, sequencing after the search bar.
- Profile — Activity feed empty state icon floats with animate-float.
- Settings — Save success/error messages appear with animate-fade-in. Delete account confirmation panel fades in when expanded. Avatar editor modal now uses backdrop fade-in + dialog modal-in to match the dashboard avatar editor.
