### PR TITLE
Feature: share button with snackbar on event cards and detail

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -111,6 +111,13 @@ body {
   to   { opacity: 1; }
 }
 
+@keyframes snackbar-show {
+  0%   { opacity: 0; transform: translateY(10px) scale(0.95); }
+  14%  { opacity: 1; transform: translateY(0)    scale(1);    }
+  80%  { opacity: 1; transform: translateY(0)    scale(1);    }
+  100% { opacity: 0; transform: translateY(-4px) scale(0.98); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   @keyframes fade-up {
     from { opacity: 0; }
@@ -134,5 +141,9 @@ body {
   @keyframes fade-in {
     from { opacity: 0; }
     to   { opacity: 1; }
+  }
+  @keyframes snackbar-show {
+    0%, 100% { opacity: 0; }
+    14%, 80%  { opacity: 1; }
   }
 }

--- a/components/events/EventShareButton.tsx
+++ b/components/events/EventShareButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { useShareLinkCopy } from "@/hooks/useShareLinkCopy";
+import { IconShare } from "@/components/events/eventDetail/EventDetailIcons";
+
+export function EventShareButton({
+  eventId,
+  variant = "badge",
+}: {
+  eventId: string;
+  variant?: "badge" | "icon";
+}) {
+  const { copied, copyUrl } = useShareLinkCopy();
+
+  function handleShare(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    copyUrl(`${window.location.origin}/events/${eventId}`);
+  }
+
+  const snackbar =
+    copied && typeof document !== "undefined"
+      ? createPortal(
+          <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] pointer-events-none animate-snackbar">
+            <div className="flex items-center gap-2.5 px-4 py-2.5 rounded-full bg-elevated/95 backdrop-blur-md border border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.5)]">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <circle cx="12" cy="12" r="10" fill="rgba(34,197,94,0.15)" stroke="#22C55E" strokeWidth="1.5" />
+                <polyline points="8 12 11 15 16 9" stroke="#22C55E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              <span className="text-sm font-medium text-text-primary whitespace-nowrap">Link copied!</span>
+            </div>
+          </div>,
+          document.body
+        )
+      : null;
+
+  if (variant === "icon") {
+    return (
+      <>
+        <button
+          onClick={handleShare}
+          title="Copy link"
+          className="p-1.5 rounded-full bg-black/40 backdrop-blur-sm text-white hover:bg-black/60 transition-colors"
+        >
+          <IconShare />
+        </button>
+        {snackbar}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <button
+        onClick={handleShare}
+        className="text-xs px-2.5 py-0.5 rounded-full border border-border text-text-secondary hover:text-text-primary hover:border-text-muted transition-colors"
+      >
+        Copy link
+      </button>
+      {snackbar}
+    </>
+  );
+}

--- a/components/events/EventsListEventCard.tsx
+++ b/components/events/EventsListEventCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { totalSlots } from "@/lib/chapterConstants";
 import { formatRelativeDate } from "@/lib/eventListFormat";
 import type { ChapterEventDoc } from "@/types/chapter";
+import { EventShareButton } from "@/components/events/EventShareButton";
 
 export function EventsListEventCard({
   event,
@@ -50,6 +51,9 @@ export function EventsListEventCard({
             Internal
           </span>
         )}
+        <div className="absolute top-3 right-3">
+          <EventShareButton eventId={event.eventId} variant="icon" />
+        </div>
       </div>
 
       <div className="p-5 flex flex-col flex-1">

--- a/components/events/PastEventRow.tsx
+++ b/components/events/PastEventRow.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { totalSlots } from "@/lib/chapterConstants";
 import type { ChapterEventDoc } from "@/types/chapter";
+import { EventShareButton } from "@/components/events/EventShareButton";
 
 export function PastEventRow({
   event,
@@ -45,6 +46,8 @@ export function PastEventRow({
           </span>
         </div>
       )}
+
+      <EventShareButton eventId={event.eventId} variant="icon" />
 
       <svg
         width="14"

--- a/components/events/eventDetail/EventDetailIcons.tsx
+++ b/components/events/eventDetail/EventDetailIcons.tsx
@@ -92,3 +92,12 @@ export function IconUpload() {
     </svg>
   );
 }
+
+export function IconShare() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}

--- a/components/events/eventDetail/EventHeaderCard.tsx
+++ b/components/events/eventDetail/EventHeaderCard.tsx
@@ -1,5 +1,6 @@
 import type { EventDoc } from "@/lib/events/types";
 import { IconCalendar, IconPin } from "./EventDetailIcons";
+import { EventShareButton } from "@/components/events/EventShareButton";
 
 interface EventHeaderCardProps {
   event: EventDoc;
@@ -68,6 +69,7 @@ export function EventHeaderCard({
               View on Luma ↗
             </a>
           )}
+          <EventShareButton eventId={event.eventId} variant="badge" />
         </div>
 
         <h1 className="font-heading text-3xl sm:text-4xl text-text-primary leading-tight">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -38,6 +38,7 @@ const config: Config = {
         "fade-in":   "fade-in 0.2s ease-out both",
         "float":     "float 3s ease-in-out infinite",
         "modal-in":  "modal-in 0.22s cubic-bezier(0.22, 1, 0.36, 1) both",
+        "snackbar":  "snackbar-show 1.8s cubic-bezier(0.16, 1, 0.3, 1) forwards",
       },
     },
   },


### PR DESCRIPTION
Adds a copy-link share button to upcoming event cards (banner overlay), past event rows, and the event detail header. Clicking any share button copies the event URL to clipboard and triggers a pill-shaped snackbar that slides up from the bottom of the screen, holds, then auto-fades out.